### PR TITLE
trim errant `\r` line feed so variables match

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -67,9 +67,9 @@ echo ".........................................."
 echo 
 
 # Check version in readme.txt is the same as plugin file after translating both to unix line breaks to work around grep's failure to identify mac line breaks
-NEWVERSION1=`grep "^Stable tag:" $GITPATH/readme.txt | awk -F' ' '{print $NF}'`
+NEWVERSION1=`grep "^Stable tag:" $GITPATH/readme.txt | awk -F' ' '{print $NF}' | tr -d '\r'`
 echo "readme.txt version: $NEWVERSION1"
-NEWVERSION2=`grep "Version:" $GITPATH/$MAINFILE | awk -F' ' '{print $NF}'`
+NEWVERSION2=`grep "Version:" $GITPATH/$MAINFILE | awk -F' ' '{print $NF}' | tr -d '\r'`
 echo "$MAINFILE version: $NEWVERSION2"
 
 if [ "$NEWVERSION1" != "$NEWVERSION2" ]; then echo "Version in readme.txt & $MAINFILE don't match. Exiting...."; exit 1; fi


### PR DESCRIPTION
I think this should fix https://github.com/GaryJones/wordpress-plugin-git-flow-svn-deploy/issues/4

It worked for me using the files I had the demonstrated the error. I don't think it will do anything to a variable that is not affected.
