### PR TITLE
Found an extra space that created error in SVN tag submission process.. ...

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -149,7 +149,7 @@ svn commit --username=$SVNUSER -m "Updating assets"
 
 echo "Creating new SVN tag and committing it"
 cd $SVNPATH
-svn copy trunk/ tags/$NEWVERSION1/
+svn copy trunk/tags/$NEWVERSION1/
 cd $SVNPATH/tags/$NEWVERSION1
 svn commit --username=$SVNUSER -m "Tagging version $NEWVERSION1"
 


### PR DESCRIPTION
...Due to the space it could not find the tag directory.

the errors were something as below 

```
Creating new SVN tag and committing it
svn: E155007: 'C:\Users\Neo\AppData\Local\Temp\wp-optimize\tags\1.8.6' is not a
working copy
deploy.sh: line 153: cd: /tmp/wp-optimize/tags/1.8.6: No such file or directory
svn: E155007: 'C:\Users\Neo\AppData\Local\Temp\wp-optimize' is not a working copy
Removing temporary directory /tmp/wp-optimize
*** FIN ***
```
