### PR TITLE
Fix error in creating new /assets directory if exists and remove /assets and /trunk from

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -150,6 +150,9 @@ svn commit --username=$SVNUSER -m "Updating assets"
 echo "Creating new SVN tag and committing it"
 cd $SVNPATH
 svn copy trunk/ tags/$NEWVERSION1/
+# Remove assets and trunk directories from tag directory
+svn delete --force $SVNPATH/tags/$NEWVERSION1/assets
+svn delete --force $SVNPATH/tags/$NEWVERSION1/trunk
 cd $SVNPATH/tags/$NEWVERSION1
 svn commit --username=$SVNUSER -m "Tagging version $NEWVERSION1"
 


### PR DESCRIPTION
/tags/$NEWVERSION1. I found that these would otherwise be uploaded to the tagged version on wp.org and consequently the user would have then downloaded into the plugin.
