### PR TITLE
Only checkout files that are needed

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -104,6 +104,7 @@ git push origin master --tags
 echo 
 echo "Creating local copy of SVN repo trunk ..."
 svn checkout $SVNURL $SVNPATH --depth immediates
+svn update $SVNPATH/trunk --set-depth infinity
 
 echo "Ignoring GitHub specific files"
 svn propset svn:ignore "README.md


### PR DESCRIPTION
`svn co $SVNURL/trunk $SVNPATH/trunk` gave me all sorts of errors. Using the changed code, the checkout is only to the level of the first child and its directories. The second line should include all subdirectories to `/trunk`.

This way all the `tags` subdirectories will not be checked out. This seems to be working here but I don't have a plugin with a lot of nested directories to really test on.
