### PR TITLE
Avoid error if xargs is empty

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -201,9 +201,9 @@ echo
 echo "Changing directory to SVN and committing to trunk."
 cd $SVNPATH/trunk/
 # Delete all files that should not now be added.
-svn status | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs svn del
+svn status | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs -r svn del
 # Add all new files that are not set to be ignored
-svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs svn add
+svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs -r svn add
 svn commit --username=$SVNUSER -m "Preparing for $PLUGINVERSION release"
 
 echo
@@ -211,9 +211,9 @@ echo
 echo "Updating WordPress plugin repo assets and committing."
 cd $SVNPATH/assets/
 # Delete all new files that are not set to be ignored
-svn status | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs svn del
+svn status | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs -r svn del
 # Add all new files that are not set to be ignored
-svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs svn add
+svn status | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs -r svn add
 svn update --quiet --accept working $SVNPATH/assets/*
 svn commit --username=$SVNUSER -m "Updating assets"
 


### PR DESCRIPTION
## Description

Sometimes is possible to find your self in a situation in which you don't have nothing to delete, in that cases the script will fail since `svn del` expect at least one file as argument.

## Fix
adding `-r`/`--no-run-if-empty` to `xargs` avoid this error to happen and make the script more reliable.

## Refs
- [svn del](http://svnbook.red-bean.com/en/1.6/svn.ref.svn.c.delete.html)
- [Ignore empty result for xargs](https://stackoverflow.com/a/8296746/4420152)
