### PR TITLE
More universal location for dot org assets, allows local assets folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Deploys a WordPress plugin from a local Git repo to the WordPress Plugin Repostiory (SVN).
 
-Please note that if your repository contains a folder `/.wordpress-org` it will be used to contain those files that will be transferred to your SVN `/assets` folder. These assets are the plugin banner images, icons, and any `readme.txt` related files.
+Please note that if your repository contains a folder `/.wordpress-org` it will be used to contain those files that will be transferred to your SVN `/assets` folder. These assets are the plugin banner images, icons, and any `readme.txt` related files. If you use a diffent name for this folder you will be prompted for that name in the script.
 
 ## Steps
 
@@ -11,23 +11,25 @@ These are the steps that the script takes:
  1. Asks for plugin slug.
  2. Asks for local plugin directory.
  3. Checks local plugin directory exists.
- 4. Asks for main plugin file name.
- 5. Checks main plugin file exists.
- 6. Checks `readme.txt` version matches main plugin file version.
- 7. Asks for temporary SVN checkout path.
- 8. Asks for remote SVN repo URL.
- 9. Asks for SVN username.
- 10. Asks if input is correct, and gives chance to abort.
- 11. Checks if Git tag exists for version number (must match exactly).
- 12. Does checkout of SVN repo.
- 13. Sets SVN ignore on some GitHub-related files.
- 14. Exports `HEAD` of `master` from Git to the trunk of SVN.
- 15. Initialises and updates any git submodules.
- 16. Moves `/trunk/.wordpress-org` up to SVN `/assets`.
- 17. Moves into `/trunk`, and does an SVN commit.
- 18. Moves into `/assets`, and does an SVN commit.
- 19. Copies `/trunk` into `/tags/{version}`, and does an SVN commit.
- 20. Deletes temporary local SVN checkout.
+ 4. Asks for local SVN assets directory.
+ 5. Checks local SVN assets directory exists.
+ 6. Asks for main plugin file name.
+ 7. Checks main plugin file exists.
+ 8. Checks `readme.txt` version matches main plugin file version.
+ 9. Asks for temporary SVN checkout path.
+ 10. Asks for remote SVN repo URL.
+ 11. Asks for SVN username.
+ 12. Asks if input is correct, and gives chance to abort.
+ 13. Checks if Git tag exists for version number (must match exactly).
+ 14. Does checkout of SVN repo.
+ 15. Sets SVN ignore on some GitHub-related files.
+ 16. Exports `HEAD` of `master` from Git to the trunk of SVN.
+ 17. Initialises and updates any git submodules.
+ 18. Moves `/trunk/.wordpress-org` up to SVN `/assets`.
+ 19. Moves into `/trunk`, and does an SVN commit.
+ 20. Moves into `/assets`, and does an SVN commit.
+ 21. Copies `/trunk` into `/tags/{version}`, and does an SVN commit.
+ 22. Deletes temporary local SVN checkout.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -8,28 +8,28 @@ Please note that if your repository contains a folder `/.wordpress-org` it will 
 
 These are the steps that the script takes:
 
- 1. Asks for plugin slug.
- 2. Asks for local plugin directory.
- 3. Checks local plugin directory exists.
- 4. Asks for local SVN assets directory.
- 5. Checks local SVN assets directory exists.
- 6. Asks for main plugin file name.
- 7. Checks main plugin file exists.
- 8. Checks `readme.txt` version matches main plugin file version.
- 9. Asks for temporary SVN checkout path.
- 10. Asks for remote SVN repo URL.
- 11. Asks for SVN username.
- 12. Asks if input is correct, and gives chance to abort.
- 13. Checks if Git tag exists for version number (must match exactly).
- 14. Does checkout of SVN repo.
- 15. Sets SVN ignore on some GitHub-related files.
- 16. Exports `HEAD` of `master` from Git to the trunk of SVN.
- 17. Initialises and updates any git submodules.
- 18. Moves `/trunk/.wordpress-org` up to SVN `/assets`.
- 19. Moves into `/trunk`, and does an SVN commit.
- 20. Moves into `/assets`, and does an SVN commit.
- 21. Copies `/trunk` into `/tags/{version}`, and does an SVN commit.
- 22. Deletes temporary local SVN checkout.
+  1. Asks for plugin slug.
+  1. Asks for local plugin directory.
+  1. Checks local plugin directory exists.
+  1. Asks for local SVN assets directory.
+  1. Checks local SVN assets directory exists.
+  1. Asks for main plugin file name.
+  1. Checks main plugin file exists.
+  1. Checks `readme.txt` version matches main plugin file version.
+  1. Asks for temporary SVN checkout path.
+  1. Asks for remote SVN repo URL.
+  1. Asks for SVN username.
+  1. Asks if input is correct, and gives chance to abort.
+  1. Checks if Git tag exists for version number (must match exactly).
+  1. Does checkout of SVN repo.
+  1. Sets SVN ignore on some GitHub-related files.
+  1. Exports `HEAD` of `master` from Git to the trunk of SVN.
+  1. Initialises and updates any git submodules.
+  1. Moves `/trunk/.wordpress-org` up to SVN `/assets`.
+  1. Moves into `/trunk`, and does an SVN commit.
+  1. Moves into `/assets`, and does an SVN commit.
+  1. Copies `/trunk` into `/tags/{version}`, and does an SVN commit.
+  1. Deletes temporary local SVN checkout.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ These are the steps that the script takes:
 
 ## Install
 
-1. In your terminal, `cd` into the directory which contains subdirectories for each of your plugins. i.e. on a local install of WordPress, this will probably be `wp-content/plugins`. Then `git clone https://github.com/GaryJones/wordpress-plugin-git-flow-svn-deploy.git .` to clone the deploy script locally.
-2. Ensure that the shell script is executable. In Mac / Unix, run `chmod +x deploy.sh`.
-3. Run the script with `sh deploy.sh`. You can also double-click it in Finder / Explorer to start it.
-4. You'll now be guided through a set of questions.
+  1. In your terminal, `cd` into the directory which contains subdirectories for each of your plugins. i.e. on a local install of WordPress, this will probably be `wp-content/plugins`. Then `git clone https://github.com/GaryJones/wordpress-plugin-git-flow-svn-deploy.git .` to clone the deploy script locally.
+  2. Ensure that the shell script is executable. In Mac / Unix, run `chmod +x deploy.sh`.
+  3. Run the script with `sh deploy.sh`. You can also double-click it in Finder / Explorer to start it.
+  4. You'll now be guided through a set of questions.
 
 I prefer to keep this script in the root of my projects directory. Each project directory is named as the plugin slug, as is the corresponding GitHub repo. To use, just call the script, enter the plugin slug, confirm or amend default suggestions, and sit back as the code is sent to SVN and git repos including tags. The commit messages here are hard-coded for consistency.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Deploys a WordPress plugin from a local Git repo to the WordPress Plugin Repostiory (SVN).
 
+Please note that if your repository contains a folder `/.wordpress-org` it will be used to contain those files that will be transferred to your SVN `/assets` folder. These assets are the plugin banner images, icons, and any `readme.txt` related files.
+
 ## Steps
 
 These are the steps that the script takes:
@@ -21,7 +23,7 @@ These are the steps that the script takes:
  13. Sets SVN ignore on some GitHub-related files.
  14. Exports `HEAD` of `master` from Git to the trunk of SVN.
  15. Initialises and updates any git submodules.
- 16. Moves `/trunk/assets` up to `/assets`.
+ 16. Moves `/trunk/.wordpress-org` up to SVN `/assets`.
  17. Moves into `/trunk`, and does an SVN commit.
  18. Moves into `/assets`, and does an SVN commit.
  19. Copies `/trunk` into `/tags/{version}`, and does an SVN commit.

--- a/deploy.sh
+++ b/deploy.sh
@@ -198,13 +198,12 @@ fi
 
 echo
 
-# Support for the /assets folder on the .org repo.
+# Support for the /assets folder on the .org repo, locally this will be /.wordpress-org
 echo "Moving assets."
 # Make the directory if it doesn't already exist
 mkdir -p $SVNPATH/assets/
-mv $SVNPATH/trunk/assets/* $SVNPATH/assets/
+mv $SVNPATH/trunk/.wordpress-org/* $SVNPATH/assets/
 svn add --force $SVNPATH/assets/
-svn delete --force $SVNPATH/trunk/assets
 
 echo
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,23 +6,25 @@
 #  1. Ask for plugin slug.
 #  2. Ask for local plugin directory.
 #  3. Check local plugin directory exists.
-#  4. Ask for main plugin file name.
-#  5. Check main plugin file exists.
-#  6. Check readme.txt version matches main plugin file version.
-#  7. Ask for temporary SVN path.
-#  8. Ask for remote SVN repo.
-#  9. Ask for SVN username.
-# 10. Ask if input is correct, and give chance to abort.
-# 11. Check if Git tag exists for version number (must match exactly).
-# 12. Checkout SVN repo.
-# 13. Set to SVN ignore some GitHub-related files.
-# 14. Export HEAD of master from git to the trunk of SVN.
-# 15. Initialise and update and git submodules.
-# 16. Move /trunk/assets up to /assets.
-# 17. Move into /trunk, and SVN commit.
-# 18. Move into /assets, and SVN commit.
-# 19. Copy /trunk into /tags/{version}, and SVN commit.
-# 20. Delete temporary local SVN checkout.
+#  4. Ask for local SVN assets directory.
+#  5. Check local SVN assets directory exists.
+#  6. Ask for main plugin file name.
+#  7. Check main plugin file exists.
+#  8. Check readme.txt version matches main plugin file version.
+#  9. Ask for temporary SVN path.
+# 10. Ask for remote SVN repo.
+# 11. Ask for SVN username.
+# 12. Ask if input is correct, and give chance to abort.
+# 13. Check if Git tag exists for version number (must match exactly).
+# 14. Checkout SVN repo.
+# 15. Set to SVN ignore some GitHub-related files.
+# 16. Export HEAD of master from git to the trunk of SVN.
+# 17. Initialise and update and git submodules.
+# 18. Move /trunk/assets up to /assets.
+# 19. Move into /trunk, and SVN commit.
+# 20. Move into /assets, and SVN commit.
+# 21. Copy /trunk into /tags/{version}, and SVN commit.
+# 22. Delete temporary local SVN checkout.
 
 echo
 echo "WordPress Plugin SVN Deploy v4.0.0"
@@ -45,6 +47,7 @@ default_svnurl="https://plugins.svn.wordpress.org/$PLUGINSLUG"
 default_svnuser="GaryJ"
 default_plugindir="$CURRENTDIR/$PLUGINSLUG"
 default_mainfile="$PLUGINSLUG.php"
+default_assetsdir=".wordpress-org"
 
 echo "Q2. Your local plugin root directory (the Git repo)."
 printf "($default_plugindir): "
@@ -59,7 +62,20 @@ if [ ! -d "$PLUGINDIR" ]; then
   exit 1;
 fi
 
-printf "Q3. Name of the main plugin file ($default_mainfile): "
+echo "Q3. Your local repository directory for SVN assets."
+printf "($default_assetsdir): "
+read -e input
+ASSETSDIR="${input:-$default_assetsdir}" # Populate with default if empty
+echo
+
+# Check if SVN assets directory exists.
+if [ ! -d "$PLUGINDIR/$ASSETSDIR" ]; then
+	echo "SVN assets directory $PLUGINDIR/$ASSETSDIR not found."
+	echo "This is not fatal but you may not have intended results."
+	echo
+fi
+
+printf "Q4. Name of the main plugin file ($default_mainfile): "
 read -e input
 MAINFILE="${input:-$default_mainfile}" # Populate with default if empty
 echo
@@ -90,21 +106,21 @@ fi
 
 echo
 
-echo "Q4. Path to a local directory where a temporary SVN checkout can be made."
+echo "Q5. Path to a local directory where a temporary SVN checkout can be made."
 printf "Don't add trunk ($default_svnpath): "
 read -e input
 input="${input%/}" # Strip trailing slash
 SVNPATH="${input:-$default_svnpath}" # Populate with default if empty
 echo
 
-echo "Q5. Remote SVN repo on WordPress.org."
+echo "Q6. Remote SVN repo on WordPress.org."
 printf "($default_svnurl): "
 read -e input
 input="${input%/}" # Strip trailing slash
 SVNURL="${input:-$default_svnurl}" # Populate with default if empty
 echo
 
-printf "Q6. Your WordPress repo SVN username ($default_svnuser): "
+printf "Q7. Your WordPress repo SVN username ($default_svnuser): "
 read -e input
 SVNUSER="${input:-$default_svnuser}" # Populate with default if empty
 echo

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@
 # 20. Delete temporary local SVN checkout.
 
 echo
-echo "WordPress Plugin SVN Deploy v3.1.0"
+echo "WordPress Plugin SVN Deploy v4.0.0"
 echo
 echo "Let's collect some information first. There are six questions."
 echo


### PR DESCRIPTION
Now uses `/.wordpress-org` as location for dot org assets. Since 10up has created the GitHub Action for similar purposes, it seems this naming structure will be better.
Fixes https://github.com/GaryJones/wordpress-plugin-svn-deploy/issues/31